### PR TITLE
Feature/studio one combine

### DIFF
--- a/KeySwitchManager/Sources/Runtime/Applications.Core/Controllers/Export/ExportControllerFactory.cs
+++ b/KeySwitchManager/Sources/Runtime/Applications.Core/Controllers/Export/ExportControllerFactory.cs
@@ -55,7 +55,7 @@ namespace KeySwitchManager.Applications.Core.Controllers.Export
                         return CreateImpl( new MultipleCubaseWriter( outputDir ) );
 
                     case ExportSupportedFormat.StudioOne:
-                        return CreateImpl( new MultipleStudioOneWriter( outputDir ) );
+                        return CreateImpl( new CombinedStudioOneWriter( outputDir ) );
 
                     case ExportSupportedFormat.Cakewalk:
                         return CreateImpl( new MultipleCakewalkWriter( outputDir ) );

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/CombinedStudioOneWriter.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/CombinedStudioOneWriter.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using KeySwitchManager.Commons.Data;
+using KeySwitchManager.Domain.KeySwitches.Helpers;
+using KeySwitchManager.Domain.KeySwitches.Models;
+using KeySwitchManager.Domain.KeySwitches.Models.Values;
+using KeySwitchManager.Infrastructures.Storage.KeySwitches.Helper;
+using KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Models;
+using KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Translators.Helpers;
+
+using RkHelper.Text.Xml;
+
+namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne
+{
+    public class CombinedStudioOneWriter : IKeySwitchWriter
+    {
+        private const string Suffix = ".keyswitch";
+
+        private DirectoryPath OutputDirectory { get; }
+        private Encoding FileEncoding { get; }
+        public bool LeaveOpen => false;
+
+        public CombinedStudioOneWriter( DirectoryPath outputDirectory ) : this( outputDirectory, Encoding.UTF8 ) {}
+
+        public CombinedStudioOneWriter( DirectoryPath outputDirectory, Encoding filEncoding )
+        {
+            OutputDirectory = outputDirectory;
+            FileEncoding    = filEncoding;
+        }
+
+        public void Dispose() {}
+
+        public void Write( IReadOnlyCollection<KeySwitch> keySwitches, IObserver<string>? logging = null )
+        {
+            if( !keySwitches.Any() )
+            {
+                throw new ArgumentException( $"{nameof( keySwitches )} is empty" );
+            }
+
+            var group = KeySwitchHelper.GroupBy( keySwitches );
+
+            foreach( var ((developerName, productName), x) in group )
+            {
+                var rootElement = KeySwitchToStudioOneModelHelper.TranslateRootElement( developerName, productName );
+
+                Translate( rootElement, developerName, productName, x, logging );
+
+                var filePath = CreatePathHelper.CreateFilePath( developerName, productName, Suffix, OutputDirectory );
+                using var stream = filePath.OpenStream( FileMode.Create, FileAccess.ReadWrite );
+                using var writer = new StreamWriter( stream, FileEncoding, IKeySwitchWriter.DefaultStreamWriterBufferSize, LeaveOpen );
+
+                var xmlText = XmlHelper.ToXmlString( rootElement );
+                writer.WriteLine( xmlText );
+            }
+        }
+
+        private static void Translate(
+            RootElement rootElement,
+            DeveloperName developerName,
+            ProductName productName,
+            IEnumerable<KeySwitch> keySwitches,
+            IObserver<string>? logging )
+        {
+            logging?.OnNext( $"{developerName} | {productName}" );
+
+            foreach( var x in keySwitches )
+            {
+                var folder = new AttributeElement
+                {
+                    Folder = "1",
+                    Name = x.InstrumentName.Value
+                };
+
+                var elementAttributes = KeySwitchToStudioOneModelHelper.TranslateElementAttributes( x.Articulations );
+                folder.Children.AddRange( elementAttributes );
+                rootElement.AttributeElements.Add( folder );
+            }
+        }
+    }
+}

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Models/ElementAttribute.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Models/ElementAttribute.cs
@@ -1,31 +1,38 @@
+using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Models
 {
-    public class ElementAttribute
+    public class AttributeElement
     {
+        [XmlAttribute( AttributeName = "folder" )]
+        public string Folder { get; set; } = default!;
+
         [XmlAttribute( AttributeName = "name" )]
         public string Name { get; set; } = string.Empty;
 
         [XmlAttribute( AttributeName = "id" )]
-        public int Id { get; set; }
+        public string Id { get; set; } = default!;
 
         [XmlAttribute( AttributeName = "color" )]
         public string Color { get; set; } = default!; // AABBGGRR
 
         [XmlAttribute( AttributeName = "pitch" )]
-        public int Pitch { get; set; }
+        public string Pitch { get; set; } = default!;
 
         [XmlAttribute( AttributeName = "momentary" )]
-        public int Momentary { get; set; }
+        public string Momentary { get; set; } = default!;
 
         [XmlAttribute( AttributeName = "activation" ) ]
-        public string Activation { get; set; } = string.Empty;
+        public string Activation { get; set; } = default!;
 
-        public ElementAttribute()
+        [XmlElement( ElementName = "Attributes" )]
+        public List<AttributeElement> Children { get; } = new();
+
+        public AttributeElement()
         {}
 
-        public ElementAttribute(
+        public AttributeElement(
             string name,
             int id,
             string color,
@@ -34,10 +41,10 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Mod
             string activation )
         {
             Name       = name;
-            Id         = id;
+            Id         = id.ToString();
             Color      = color;
-            Pitch      = pitch;
-            Momentary  = momentary;
+            Pitch      = pitch.ToString();
+            Momentary  = momentary.ToString();
             Activation = activation;
         }
     }

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Models/RootElement.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Models/RootElement.cs
@@ -7,7 +7,7 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Mod
     public class RootElement
     {
         [XmlElement( ElementName = "Attributes" )]
-        public List<ElementAttribute> Attributes { get; set; } = new List<ElementAttribute>();
+        public List<AttributeElement> AttributeElements { get; set; } = new();
 
         [XmlAttribute( AttributeName = "name" )]
         public string Name { get; set; } = string.Empty;

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/MultipleStudioOneWriter.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/MultipleStudioOneWriter.cs
@@ -8,6 +8,7 @@ using KeySwitchManager.Infrastructures.Storage.KeySwitches.Helper;
 
 namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne
 {
+    [Obsolete]
     public class MultipleStudioOneWriter : IKeySwitchWriter
     {
         private const string Suffix = ".keyswitch";

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/StudioOneWriter.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/StudioOneWriter.cs
@@ -9,6 +9,7 @@ using KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Transla
 
 namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne
 {
+    [Obsolete]
     public sealed class StudioOneWriter : IKeySwitchWriter
     {
         private Encoding FileEncoding { get; }

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Translators/Helpers/KeySwitchToStudioOneModelHelper.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Translators/Helpers/KeySwitchToStudioOneModelHelper.cs
@@ -18,27 +18,33 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Tra
             var rootElement = TranslateRootElement( source );
             var attributeElements = TranslateElementAttributes( source.Articulations );
 
-            rootElement.Attributes.AddRange( attributeElements );
+            rootElement.AttributeElements.AddRange( attributeElements );
 
             return rootElement;
         }
 
         #region Translate Attribute
-        public static RootElement TranslateRootElement( ProductName productName )
-            => new()
-            {
-                Name = $"{productName.Value}"
-            };
-
         public static RootElement TranslateRootElement( KeySwitch source )
             => new()
             {
-                Name = $"{source.ProductName.Value} {source.InstrumentName.Value}"
+                Name = $"{source.ProductName.Value} {source.InstrumentName}"
             };
 
-        public static IReadOnlyCollection<ElementAttribute> TranslateElementAttributes( IEnumerable<Articulation> articulations )
+        public static RootElement TranslateRootElement( DeveloperName developerName, ProductName productName )
+            => new()
+            {
+                Name = $"{developerName.Value} {productName.Value}"
+            };
+
+        public static RootElement TranslateRootElement( ProductName productName, InstrumentName instrumentName  )
+            => new()
+            {
+                Name = $"{productName.Value} {instrumentName.Value}"
+            };
+
+        public static IReadOnlyCollection<AttributeElement> TranslateElementAttributes( IEnumerable<Articulation> articulations )
         {
-            var result = new List<ElementAttribute>();
+            var result = new List<AttributeElement>();
             var id = 0;
 
             foreach( var i in articulations )
@@ -57,7 +63,7 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Tra
             return result;
         }
 
-        private static ElementAttribute TranslateElementAttribute( Articulation articulation, int id )
+        private static AttributeElement TranslateElementAttribute( Articulation articulation, int id )
         {
             var name = articulation.ArticulationName.Value;
             var pitch = articulation.MidiNoteOns[ 0 ].DataByte1.Value;
@@ -74,7 +80,7 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Tra
                 ExtraDataKeys.Momentary, new ExtraDataValue( "0" )
             ).Value == "0" ? 0 : 1;
 
-            return new ElementAttribute( name, id, color, pitch, momentary, activation );
+            return new AttributeElement( name, id, color, pitch, momentary, activation );
         }
 
         #region Translate Activations

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Translators/Helpers/KeySwitchToStudioOneModelHelper.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Translators/Helpers/KeySwitchToStudioOneModelHelper.cs
@@ -15,14 +15,33 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Tra
     {
         public static RootElement Translate( KeySwitch source )
         {
-            var rootElement = new RootElement
+            var rootElement = TranslateRootElement( source );
+            var attributeElements = TranslateElementAttributes( source.Articulations );
+
+            rootElement.Attributes.AddRange( attributeElements );
+
+            return rootElement;
+        }
+
+        #region Translate Attribute
+        public static RootElement TranslateRootElement( ProductName productName )
+            => new()
+            {
+                Name = $"{productName.Value}"
+            };
+
+        public static RootElement TranslateRootElement( KeySwitch source )
+            => new()
             {
                 Name = $"{source.ProductName.Value} {source.InstrumentName.Value}"
             };
 
+        public static IReadOnlyCollection<ElementAttribute> TranslateElementAttributes( IEnumerable<Articulation> articulations )
+        {
+            var result = new List<ElementAttribute>();
             var id = 0;
 
-            foreach( var i in source.Articulations )
+            foreach( var i in articulations )
             {
                 if( !i.MidiNoteOns.Any() )
                 {
@@ -32,13 +51,12 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Tra
                 var attr = TranslateElementAttribute( i, id );
                 id++;
 
-                rootElement.Attributes.Add( attr );
+                result.Add( attr );
             }
 
-            return rootElement;
+            return result;
         }
 
-        #region Translate Attribute
         private static ElementAttribute TranslateElementAttribute( Articulation articulation, int id )
         {
             var name = articulation.ArticulationName.Value;

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage/KeySwitches/Helper/CreatePathHelper.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage/KeySwitches/Helper/CreatePathHelper.cs
@@ -74,6 +74,10 @@ namespace KeySwitchManager.Infrastructures.Storage.KeySwitches.Helper
             );
         }
 
+        public static FilePath CreateFilePath( DeveloperName developerName, ProductName productName, string suffix, DirectoryPath baseDirectory, params DirectoryPath[] subDirectories )
+        {
+            return CreateFilePath( developerName, productName, string.Empty, suffix, baseDirectory );
+        }
 
         public static FilePath CreateFilePath( KeySwitch keySwitch, string suffix, DirectoryPath baseDirectory, params DirectoryPath[] subDirectories )
         {


### PR DESCRIPTION
## Studio One

### 1製品につき、1 keyswitchファイル生成に

１トラックに対するキースイッチのマップではなく、１インストゥルメントに対してのマップなため
トラックを分けた場合、１つのキースイッチのマップにしかアクセスできないため、従来の１パッチ１ファイルをやめた