### PR TITLE
Studio One の出力時にノートオンが無い場合に出力をスキップしていた問題を修正

### DIFF
--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Models/ElementAttribute.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Models/ElementAttribute.cs
@@ -5,6 +5,8 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Mod
 {
     public class AttributeElement
     {
+        public const int NoPitch = -1;
+
         [XmlAttribute( AttributeName = "folder" )]
         public string Folder { get; set; } = default!;
 
@@ -43,9 +45,17 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Mod
             Name       = name;
             Id         = id.ToString();
             Color      = color;
-            Pitch      = pitch.ToString();
+            Pitch      = pitch != NoPitch ? pitch.ToString() : default!;
             Momentary  = momentary.ToString();
             Activation = activation;
         }
+
+        public AttributeElement(
+            string name,
+            int id,
+            string color,
+            int momentary,
+            string activation ) : this( name, id, color, NoPitch, momentary, activation )
+        {}
     }
 }

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Translators/StudioOneExportTranslator.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Xml/KeySwitches/StudioOne/Translators/StudioOneExportTranslator.cs
@@ -66,11 +66,6 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Tra
 
             foreach( var i in articulations )
             {
-                if( !i.MidiNoteOns.Any() )
-                {
-                    continue;
-                }
-
                 var attr = TranslateElementAttribute( i, id );
                 id++;
 
@@ -83,10 +78,15 @@ namespace KeySwitchManager.Infrastructures.Storage.Xml.KeySwitches.StudioOne.Tra
         private static AttributeElement TranslateElementAttribute( Articulation articulation, int id )
         {
             var name = articulation.ArticulationName.Value;
-            var pitch = articulation.MidiNoteOns[ 0 ].DataByte1.Value;
+            var pitch = AttributeElement.NoPitch;
             var activation = TranslateActivation( articulation );
 
             string color = default!;
+
+            if( articulation.MidiNoteOns.Any() )
+            {
+                pitch = articulation.MidiNoteOns[ 0 ].DataByte1.Value;
+            }
 
             if( articulation.ExtraData.ContainsKey( ExtraDataKeys.Color ) )
             {


### PR DESCRIPTION
CCのみでノートオンがない場合に処理をスキップしてしまっていたため修正。
xmlの`pitch`属性はノート音がある場合かつにのみ`index 0`のノートナンバーを割り当てるようにした