### PR TITLE
ロケール変換を行わない純粋なUTCで時刻情報を保持するように修正

### DIFF
--- a/KeySwitchManager/Sources/Runtime/Commons/Data/UtcDateTime.cs
+++ b/KeySwitchManager/Sources/Runtime/Commons/Data/UtcDateTime.cs
@@ -28,7 +28,7 @@ namespace KeySwitchManager.Commons.Data
         }
 
         public static DateTime NowAsDateTime
-            => TimeZoneInfo.ConvertTimeToUtc( DateTime.Now );
+            => DateTime.UtcNow;
 
         public int Year { get; }
         public int Month { get; }

--- a/KeySwitchManager/Sources/Runtime/Domain/KeySwitches/Helpers/KeySwitchFactoryHelper.cs
+++ b/KeySwitchManager/Sources/Runtime/Domain/KeySwitches/Helpers/KeySwitchFactoryHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+using KeySwitchManager.Commons.Data;
 using KeySwitchManager.Domain.KeySwitches.Models;
 using KeySwitchManager.Domain.KeySwitches.Models.Aggregations;
 using KeySwitchManager.Domain.KeySwitches.Models.Factory;
@@ -30,8 +31,8 @@ namespace KeySwitchManager.Domain.KeySwitches.Helpers
                 Guid.NewGuid(),
                 "Author",
                 "Description",
-                DateTime.Now,
-                DateTime.Now,
+                UtcDateTime.NowAsDateTime,
+                UtcDateTime.NowAsDateTime,
                 "Developer Name",
                 "Product name",
                 "Instrument name",


### PR DESCRIPTION
## Unify time information for creation and update to UTC

### Note

Since the time information in the existing sound output file will be in UTC from the next time, all the relevant sections will be differentiated. Since no process branching is performed based on time information, there is no effect on the operation.

----

## 作成時と更新時の時刻情報をUTCに統一

### 備考

既存音出力済みのファイルの時刻情報は次回からUTCになるので、該当箇所は全て差分が発生する。時刻情報で処理分岐を行っているわけではないため、動作上は影響はない。

