### PR TITLE
Refactor/utf8 non bom

### DIFF
--- a/KeySwitchManager/Sources/Runtime/Commons/Helpers/EncodingHelper.cs
+++ b/KeySwitchManager/Sources/Runtime/Commons/Helpers/EncodingHelper.cs
@@ -8,7 +8,5 @@ namespace KeySwitchManager.Commons.Helpers
         public static Encoding UTF8 => Encoding.UTF8;
         public static Encoding UTF8N { get; } = new UTF8Encoding( false );
         // ReSharper restore InconsistentNaming
-
-        public static Encoding Default => UTF8N;
     }
 }

--- a/KeySwitchManager/Sources/Runtime/Commons/Helpers/EncodingHelper.cs
+++ b/KeySwitchManager/Sources/Runtime/Commons/Helpers/EncodingHelper.cs
@@ -1,0 +1,14 @@
+using System.Text;
+
+namespace KeySwitchManager.Commons.Helpers
+{
+    public static class EncodingHelper
+    {
+        // ReSharper disable InconsistentNaming
+        public static Encoding UTF8 => Encoding.UTF8;
+        public static Encoding UTF8N { get; } = new UTF8Encoding( false );
+        // ReSharper restore InconsistentNaming
+
+        public static Encoding Default => UTF8N;
+    }
+}

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Yaml/KeySwitches/Import/YamlImportContentReader.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Yaml/KeySwitches/Import/YamlImportContentReader.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 using KeySwitchManager.Commons.Data;
+using KeySwitchManager.Commons.Helpers;
 using KeySwitchManager.Domain.KeySwitches.Models;
 using KeySwitchManager.Infrastructures.Storage.Yaml.KeySwitches.Translators;
 using KeySwitchManager.UseCase.KeySwitches.Import;
@@ -16,7 +16,7 @@ namespace KeySwitchManager.Infrastructures.Storage.Yaml.KeySwitches.Import
         public async Task<IReadOnlyCollection<KeySwitch>> ReadAsync( IContent content, CancellationToken cancellationToken = default )
         {
             await using var stream = await content.GetContentStreamAsync( cancellationToken );
-            using var reader = new StreamReader( stream, Encoding.UTF8, true );
+            using var reader = new StreamReader( stream, EncodingHelper.UTF8N );
 
             var jsonText = await reader.ReadToEndAsync();
 

--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Yaml/KeySwitches/YamlMemoryRepository.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Yaml/KeySwitches/YamlMemoryRepository.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using KeySwitchManager.Commons.Data;
+using KeySwitchManager.Commons.Helpers;
 using KeySwitchManager.Domain.KeySwitches;
 using KeySwitchManager.Infrastructures.Storage.Yaml.KeySwitches.Translators;
 
@@ -20,7 +21,7 @@ namespace KeySwitchManager.Infrastructures.Storage.Yaml.KeySwitches
 
             try
             {
-                reader = new StreamReader( stream, Encoding.UTF8 );
+                reader = new StreamReader( stream, EncodingHelper.UTF8N );
                 var yaml = reader.ReadToEnd();
                 KeySwitches.AddRange( new YamlKeySwitchImportTranslator().Translate( new PlainText( yaml ) ) );
             }
@@ -36,7 +37,7 @@ namespace KeySwitchManager.Infrastructures.Storage.Yaml.KeySwitches
 
         public override async Task WriteBinaryToAsync( Stream stream, CancellationToken cancellationToken = default )
         {
-            await using var writer = new StreamWriter( stream, Encoding.UTF8 );
+            await using var writer = new StreamWriter( stream, EncodingHelper.UTF8N );
 
             var yaml = new ReadOnlyMemory<char>(
                 new YamlKeySwitchExportTranslator().Translate( KeySwitches ).Value.ToCharArray()

--- a/KeySwitchManager/Sources/Runtime/UseCases/KeySwitches/Export/StringContent.cs
+++ b/KeySwitchManager/Sources/Runtime/UseCases/KeySwitches/Export/StringContent.cs
@@ -2,6 +2,8 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 
+using KeySwitchManager.Commons.Helpers;
+
 namespace KeySwitchManager.UseCase.KeySwitches.Export
 {
     public class StringContent : IContent
@@ -9,7 +11,7 @@ namespace KeySwitchManager.UseCase.KeySwitches.Export
         private readonly string data;
         private readonly Encoding encoding;
 
-        public StringContent( string data ) : this( data, Encoding.UTF8 ) {}
+        public StringContent( string data ) : this( data, EncodingHelper.UTF8N ) {}
 
         public StringContent( string data, Encoding encoding )
         {


### PR DESCRIPTION
Fixed to create wrapper without direct reference to Encoding.UTF8 and use UTF8N (=no BOM)

---

Encoding.UTF8 を直接参照せずにラッパーを作成し、UTF８N (=BOM無し) を使用するように修正