### PR TITLE
Fixed crash on some platforms due to resource access in Dispose

### DIFF
--- a/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Yaml/KeySwitches/YamlFileRepository.cs
+++ b/KeySwitchManager/Sources/Runtime/Infrastructures/Storage.Yaml/KeySwitches/YamlFileRepository.cs
@@ -13,11 +13,6 @@ namespace KeySwitchManager.Infrastructures.Storage.Yaml.KeySwitches
             YamlFilePath = filePath;
         }
 
-        public override async void Dispose()
-        {
-            await FlushAsync( default );
-        }
-
         public override async Task<int> FlushAsync( CancellationToken cancellationToken = default )
         {
             await using var stream = YamlFilePath.OpenWriteStream();


### PR DESCRIPTION
In fact, Flush was unnecessary for each dispose because it was executed at the time when Flush was desired.